### PR TITLE
Fixes crash if there is no media metadata available and the app tries to process it

### DIFF
--- a/app/src/main/java/com/itachi1706/cheesecakeutilities/Modules/LyricFinder/LyricNotificationListener.java
+++ b/app/src/main/java/com/itachi1706/cheesecakeutilities/Modules/LyricFinder/LyricNotificationListener.java
@@ -117,6 +117,7 @@ public class LyricNotificationListener extends NotificationListenerService {
     }
 
     private void processMetadata(@Nullable MediaMetadata metadata) {
+        if (metadata == null) return; // Don't process if no metadata
         nowPlaying.setAlbum(metadata.getString(MediaMetadata.METADATA_KEY_ALBUM));
         nowPlaying.setTitle(metadata.getString(MediaMetadata.METADATA_KEY_TITLE));
         nowPlaying.setArtist(metadata.getString(MediaMetadata.METADATA_KEY_ARTIST));


### PR DESCRIPTION
Closes #168