### PR TITLE
CUTILAND-388 Added issue template to redirect to JIRA

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report-feature-requests.md
+++ b/.github/ISSUE_TEMPLATE/bug-report-feature-requests.md
@@ -1,0 +1,17 @@
+---
+name: Bug Report/Feature Requests
+about: Use this for any bug reports or feature requests
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+Note that the main issue board for this project is located on JIRA. Direct link [here](https://itachi1706.atlassian.net/browse/CUTILAND)
+
+For quick responses, please head over to the [Support Page](https://itachi1706.atlassian.net/servicedesk/customer/portal/3) to raise a new bug report or feature requests
+
+While we will still respond to issues created here, please do note that we might not respond to the issue fast and may also continue conversation on a linked JIRA issue with this issue you are reporting (this issue will be labelled with **tracking-jira** if that is the case.
+
+If you acknowledge this please check the checkbox
+- [ ] I acknowledge that i read the above and that this issue may not be responded fast


### PR DESCRIPTION
As we are now primarily using JIRA for this project, we will add an issue template to redirect users to report with the Jira Service Desk which will allow easier interaction on issues as well as allow for faster response

This is because it will allow us to not be tracking and linking 2 issue trackers and consolidate them together. While we will still look at the existing issue board in case there ARE issues posted there, it will not be as common and confirmed bugs/feature issues will be migrated over to Jira as well

Resolves CUTILAND-388