### PR TITLE
CUTILAND-379 Renamed all references of fingerprint to biometric

### DIFF
--- a/app/src/main/java/com/itachi1706/cheesecakeutilities/GeneralSettingsActivity.kt
+++ b/app/src/main/java/com/itachi1706/cheesecakeutilities/GeneralSettingsActivity.kt
@@ -39,9 +39,9 @@ class GeneralSettingsActivity : AppCompatActivity() {
                     resources.getString(R.string.link_legacy), resources.getString(R.string.link_updates), this)
             super.addEggMethods(false, null, true) { Attribouter.from(context).show(); true }
 
-            val fpPw: Preference? = findPreference("password_fp")
+            val bioPw: Preference? = findPreference("password_fp")
             sp = PrefHelper.getDefaultSharedPreferences(activity)
-            updatePasswordViews(fpPw)
+            updatePasswordViews(bioPw)
 
             findPreference<Preference>("testpw")?.setOnPreferenceClickListener {
                 startActivity(Intent(activity, AuthenticationActivity::class.java))
@@ -59,12 +59,12 @@ class GeneralSettingsActivity : AppCompatActivity() {
             }
 
             findPreference<Preference>(BiometricCompatHelper.APP_BIOMETRIC_COMPAT_ENABLED)?.setOnPreferenceChangeListener { _, newValue ->
-                updatePasswordViews(fpPw, newValue as Boolean, 0)
+                updatePasswordViews(bioPw, newValue as Boolean, 0)
                 true
             }
 
             findPreference<Preference>(BiometricCompatHelper.SCREEN_LOCK_ENABLED)?.setOnPreferenceChangeListener { _, newValue ->
-                updatePasswordViews(fpPw, newValue as Boolean, 1)
+                updatePasswordViews(bioPw, newValue as Boolean, 1)
                 true
             }
 
@@ -105,30 +105,30 @@ class GeneralSettingsActivity : AppCompatActivity() {
             findPreference<Preference>(BiometricCompatHelper.APP_BIOMETRIC_COMPAT_ENABLED)?.isEnabled = hasSL
         }
 
-        private fun updatePasswordViews(fpPw: Preference?, value: Boolean = BiometricCompatHelper.requireFPAuth(sp), type: Int = -1) {
+        private fun updatePasswordViews(bioPw: Preference?, value: Boolean = BiometricCompatHelper.requireBiometricAuth(sp), type: Int = -1) {
             var isScreenLock = BiometricCompatHelper.isScreenLockProtectionEnabled(activity!!)
-            var isFP = BiometricCompatHelper.requireFPAuth(sp)
+            var isBiometric = BiometricCompatHelper.requireBiometricAuth(sp)
 
             when (type) {
-                0 -> isFP = value
+                0 -> isBiometric = value
                 1 -> isScreenLock = value
             }
             var summary = "Unprotected"
             if (isScreenLock) {
                 if (BiometricCompatHelper.isScreenLockEnabled(activity!!)) {
                     summary = "Protected with device screen lock"
-                    if (isFP) {
-                        if (BiometricCompatHelper.isBiometricFPRegistered(activity!!)) summary = "Protected with fingerprint + screen lock"
-                        else summary += " (No fingerprint found on device)"
+                    if (isBiometric) {
+                        if (BiometricCompatHelper.isBiometricRegistered(activity!!)) summary = "Protected with biometrics + screen lock"
+                        else summary += " (No biometric data found on device)"
                     }
                 } else summary = "Unprotected (No screen lock found)"
-            } else if (isFP) {
-                summary = if (!BiometricCompatHelper.isScreenLockEnabled(activity!!)) "Unprotected (No screen lock found)" // No FP without a screen lock
-                else if (BiometricCompatHelper.isBiometricFPRegistered(activity!!)) "Protected with fingerprint"
-                else "Unprotected (No fingerprint found on device)"
+            } else if (isBiometric) {
+                summary = if (!BiometricCompatHelper.isScreenLockEnabled(activity!!)) "Unprotected (No screen lock found)" // No Biometrics without a screen lock
+                else if (BiometricCompatHelper.isBiometricRegistered(activity!!)) "Protected with biometrics"
+                else "Unprotected (No biometric data found on device)"
             }
 
-            fpPw?.summary = summary
+            bioPw?.summary = summary
         }
 
         override fun getMusicResource(): Int {

--- a/app/src/main/java/com/itachi1706/cheesecakeutilities/features/biometricAuth/AuthenticationActivity.java
+++ b/app/src/main/java/com/itachi1706/cheesecakeutilities/features/biometricAuth/AuthenticationActivity.java
@@ -43,8 +43,8 @@ public class AuthenticationActivity extends AppCompatActivity {
 
         sp = PrefHelper.getDefaultSharedPreferences(this);
         migrateToBiometric();
-        if (BiometricCompatHelper.Companion.isBiometricFPRegistered(this) && BiometricCompatHelper.Companion.requireFPAuth(sp)) {
-            // Has Fingerprint and requested for fingerprint auth
+        if (BiometricCompatHelper.Companion.isBiometricRegistered(this) && BiometricCompatHelper.Companion.requireBiometricAuth(sp)) {
+            // Has Biometrics and requested for biometric auth
             Executor executor = BiometricCompatHelper.Companion.getBiometricExecutor();
             BiometricPrompt p = new BiometricPrompt(this, executor, callback);
             BiometricPrompt.PromptInfo promptInfo = BiometricCompatHelper.Companion.createPromptObject();
@@ -110,9 +110,9 @@ public class AuthenticationActivity extends AppCompatActivity {
                             Toast.makeText(mContext, R.string.dialog_cancelled, Toast.LENGTH_SHORT).show();
                             LogHelper.i(TAG, "User Lock out");
                             intent.putExtra(INTENT_MSG, "Lockout");
-                            new AlertDialog.Builder(mContext).setTitle("Fingerprint sensor disabled (Locked out)")
-                                    .setMessage("You have scanned an invalid fingerprint too many times and your fingerprint sensor has been disabled. \n\n" +
-                                            "Please re-authenticate by unlocking or rebooting your phone again or disable fingerprints on your device")
+                            new AlertDialog.Builder(mContext).setTitle("Biometric sensors disabled (Locked out)")
+                                    .setMessage("You have attempted and failed biometric authentication too many times and your biometric sensors has been disabled. \n\n" +
+                                            "Please re-authenticate by unlocking or rebooting your phone again or disable biometric authentication on your device")
                                     .setCancelable(false).setPositiveButton(R.string.dialog_action_positive_close, (dialog, which) -> {
                                 setResult(RESULT_CANCELED, intent);
                                 finish();

--- a/app/src/main/java/com/itachi1706/cheesecakeutilities/features/biometricAuth/BiometricCompatHelper.kt
+++ b/app/src/main/java/com/itachi1706/cheesecakeutilities/features/biometricAuth/BiometricCompatHelper.kt
@@ -13,7 +13,7 @@ import java.util.concurrent.Executor
 
 /**
  * Created by Kenneth on 14/12/2018.
- * for com.itachi1706.appupdater.extlib.fingerprint in CheesecakeUtilities
+ * for com.itachi1706.features.biometricAuth in CheesecakeUtilities
  */
 class BiometricCompatHelper private constructor() {
 
@@ -27,17 +27,17 @@ class BiometricCompatHelper private constructor() {
         const val SCREEN_LOCK_ENABLED = "app_screen_lock_protection"
 
         /**
-         * Check if we need to authenticate with Fingerprint through the BiometricPromptCompat API
+         * Check if we need to authenticate with Biometrics through the BiometricPromptCompat API
          * @param sp Shared Preference Object
-         * @return true if require fingerprint, false otherwise
+         * @return true if require biometrics, false otherwise
          */
-        fun requireFPAuth(sp: SharedPreferences): Boolean {
+        fun requireBiometricAuth(sp: SharedPreferences): Boolean {
             return sp.getBoolean(APP_BIOMETRIC_COMPAT_ENABLED, false)
         }
 
         @TargetApi(Build.VERSION_CODES.M)
         @Throws(NullPointerException::class)
-        fun isBiometricFPRegistered(context: Context): Boolean {
+        fun isBiometricRegistered(context: Context): Boolean {
             if (!isBiometricAuthAvailable(context)) return false
 
 
@@ -61,7 +61,7 @@ class BiometricCompatHelper private constructor() {
         }
 
         @JvmOverloads
-        fun createPromptObject(title: String = "Sign In", subtitle: String? = null, description: String = "Confirm fingerprint to continue", negativeBtn: String = "Cancel"): BiometricPrompt.PromptInfo {
+        fun createPromptObject(title: String = "Sign In", subtitle: String? = null, description: String = "Confirm biometrics to continue", negativeBtn: String = "Cancel"): BiometricPrompt.PromptInfo {
             return BiometricPrompt.PromptInfo.Builder().setTitle(title).setSubtitle(subtitle).setDescription(description).setNegativeButtonText(negativeBtn).build()
         }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -33,7 +33,7 @@
     <string name="pref_hint_util_visibility">Hide/Show Utility</string>
     <string name="pref_hint_util_lock">Lock/Unlock utility</string>
 
-    <!-- Fingerprint -->
+    <!-- Biometric Authentication -->
     <string name="dialog_authenticated">Authenticated</string>
     <string name="dialog_cancelled">Authentication cancelled</string>
 

--- a/app/src/main/res/xml/pref_general.xml
+++ b/app/src/main/res/xml/pref_general.xml
@@ -13,8 +13,8 @@
 
     <PreferenceCategory android:title="Authentication">
         <Preference android:title="Authentication Status" android:selectable="false" android:key="password_fp" android:summary="Unprotected" />
-        <SwitchPreference android:title="Use Fingerprint Authentication" android:key="app_bio_compat_enable"
-            android:summary="Enable fingerprint authentication (if supported)" android:defaultValue="false" />
+        <SwitchPreference android:title="Use Biometric Authentication" android:key="app_bio_compat_enable"
+            android:summary="Enable biometric authentication (if supported)" android:defaultValue="false" />
         <SwitchPreference android:title="Screen Lock Authentication" android:key="app_screen_lock_protection"
             android:summary="Authenticate the application with your device screen lock (if screen lock is enabled)" android:defaultValue="false" />
         <SwitchPreference android:title="Global Lock" android:key="global_applock"


### PR DESCRIPTION
This is to prevent alternative authentications (like Face Unlock on P4) from showing "Confirm/Unlock with Fingerprint" when it does not have a fingerprint sensor

Resolves CUTILAND-379