### PR TITLE
CUTILAND-368 Fixed a bug where successful authentication is treated as cancelled

### DIFF
--- a/app/src/main/java/com/itachi1706/cheesecakeutilities/BaseActivity.kt
+++ b/app/src/main/java/com/itachi1706/cheesecakeutilities/BaseActivity.kt
@@ -26,6 +26,8 @@ abstract class BaseActivity : AppCompatActivity() {
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        val sp = PrefHelper.getDefaultSharedPreferences(this)
+        PrefHelper.handleDefaultThemeSwitch(sp.getString("app_theme", "batterydefault"))
         super.onCreate(savedInstanceState)
 
         val fabric = Fabric.Builder(this).kits(Crashlytics()).debuggable(BuildConfig.DEBUG).build()
@@ -34,8 +36,6 @@ abstract class BaseActivity : AppCompatActivity() {
         val checkGlobal = this.intent.hasExtra("globalcheck") && this.intent.extras!!.getBoolean("globalcheck")
         val authagain = !this.intent.hasExtra("authagain") || this.intent.extras!!.getBoolean("authagain")
         if (!authagain) return
-        val sp = PrefHelper.getDefaultSharedPreferences(this)
-        GeneralSettingsActivity.GeneralPreferenceFragment.updateDarkModeSetting(sp.getString("app_theme", "batterydefault")!!)
         if (!(menuitem == null || menuitem.isEmpty() || menuitem == "")) {
             if (!CommonMethods.isGlobalLocked(sp) && CommonMethods.isUtilityLocked(sp, menuitem)) {
                 Log.i("Authentication", "Requesting Utility Authentication for $menuitem")

--- a/app/src/main/java/com/itachi1706/cheesecakeutilities/MainMenuActivity.java
+++ b/app/src/main/java/com/itachi1706/cheesecakeutilities/MainMenuActivity.java
@@ -35,6 +35,8 @@ public class MainMenuActivity extends AppCompatActivity {
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
+        sp = PrefHelper.getDefaultSharedPreferences(this);
+        PrefHelper.handleDefaultThemeSwitch(sp.getString("app_theme", "batterydefault"));
         super.onCreate(savedInstanceState);
 
         // Error Handling
@@ -55,7 +57,6 @@ public class MainMenuActivity extends AppCompatActivity {
 
         toolbar = findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);
-        sp = PrefHelper.getDefaultSharedPreferences(this);
 
         pager = findViewById(R.id.main_viewpager);
         tabLayout = findViewById(R.id.main_tablayout);
@@ -64,8 +65,6 @@ public class MainMenuActivity extends AppCompatActivity {
         tabLayout.setupWithViewPager(pager);
         tabLayout.setTabGravity(TabLayout.GRAVITY_FILL);
         tabLayout.setTabMode(TabLayout.MODE_FIXED);
-
-        GeneralSettingsActivity.GeneralPreferenceFragment.Companion.updateDarkModeSetting(sp.getString("app_theme", "batterydefault"));
 
         // Do Authentication
         if (!this.getIntent().getBooleanExtra("authagain", true)) {


### PR DESCRIPTION
This is apparently caused by the DayNight app handling restarting the activity when changing themes due to it invoking a configuration change (and hence activity restart) when the theme changes. Due to this it actually invoked the authentication activity twice (1 cancelled, and 1 waiting user input). When the user authenticate and causes a return, the authentication activity actually returns the cancelled one first, causing the calling activity to exit due to failure in authentication

This CR fixes it by making the theme change check appear BEFORE the activity is created so that double configuration changes does not occur

Fixes CUTILAND-368

Signed-off-by: itachi1706 <kennethsohyq@gmail.com>