### PR TITLE
CUTILAND-363 TravisCI KVM Support Update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ before_install:
   - wget -q "${ANDROID_TOOLS_URL}" -O android-sdk-tools.zip
   - unzip -q android-sdk-tools.zip -d ${ANDROID_HOME}
   - rm android-sdk-tools.zip
-  - mkdir ~/.android
+  - mkdir -p ~/.android
   - echo 'count=0' > ~/.android/repositories.cfg
   - yes | sdkmanager --licenses >/dev/null
   - yes | sdkmanager "platform-tools"

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,15 +49,15 @@ before_install:
   - mkdir -p ~/.android
   - echo 'count=0' > ~/.android/repositories.cfg
   - yes | sdkmanager --licenses >/dev/null
-  - yes | sdkmanager "platform-tools"
-  - yes | sdkmanager "tools"
-  - yes | sdkmanager "build-tools;$ANDROID_BUILD_TOOLS_VERSION"
-  - yes | sdkmanager "platforms;android-$API_LEVEL" # Current Android compileSDK
+  - yes | sdkmanager "platform-tools" >/dev/null
+  - yes | sdkmanager "tools" >/dev/null
+  - yes | sdkmanager "build-tools;$ANDROID_BUILD_TOOLS_VERSION" >/dev/null
+  - yes | sdkmanager "platforms;android-$API_LEVEL" >/dev/null # Current Android compileSDK
 install:
   # Download Emulator Files
-  - yes | sdkmanager "platforms;android-$ANDROID_EMULATOR_API_LEVEL" # Android Emulator Platform
-  - yes | sdkmanager "emulator"
-  - yes | sdkmanager "system-images;android-$ANDROID_EMULATOR_API_LEVEL;$ANDROID_FLAVOUR;$ANDROID_ABI" # Android Emulator Image
+  - yes | sdkmanager "platforms;android-$ANDROID_EMULATOR_API_LEVEL" >/dev/null # Android Emulator Platform
+  - yes | sdkmanager "emulator" >/dev/null
+  - yes | sdkmanager "system-images;android-$ANDROID_EMULATOR_API_LEVEL;$ANDROID_FLAVOUR;$ANDROID_ABI" >/dev/null # Android Emulator Image
 
   # Setup Linux KVM
   - sudo -E apt-get -yq --no-install-suggests --no-install-recommends install bridge-utils libpulse0 libvirt-bin qemu-kvm virtinst ubuntu-vm-builder

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,14 +65,14 @@ install:
   - sudo adduser $USER kvm
 
   # Launch Android Emulator
-  - avdmanager list target -c
+  - avdmanager list
   - chmod +x ./travisscript/startemu.sh
   - chmod +x ./travisscript/android-wait-for-emulator.sh
   - ./travisscript/startemu.sh
 
   # Switch back to target JDK
   - JDK="${TARGET_JDK}"
-  - source ~/.install-jdk-travis.sh
+  - source ./travisscript/install-jdk-travis.sh
 before_script:
   # Original Steps continued
   #- mkdir "$ANDROID_HOME/licenses" || true

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,10 +52,10 @@ before_install:
   - yes | sdkmanager "platform-tools"
   - yes | sdkmanager "tools"
   - yes | sdkmanager "build-tools;$ANDROID_BUILD_TOOLS_VERSION"
-  - yes | sdkmanager "platform;android-$API_LEVEL" # Current Android compileSDK
+  - yes | sdkmanager "platforms;android-$API_LEVEL" # Current Android compileSDK
 install:
   # Download Emulator Files
-  - yes | sdkmanager "platform;android-$ANDROID_EMULATOR_API_LEVEL" # Android Emulator Platform
+  - yes | sdkmanager "platforms;android-$ANDROID_EMULATOR_API_LEVEL" # Android Emulator Platform
   - yes | sdkmanager "emulator"
   - yes | sdkmanager "system-images;android-$ANDROID_EMULATOR_API_LEVEL;$ANDROID_FLAVOUR;$ANDROID_ABI" # Android Emulator Image
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,17 +55,17 @@ before_install:
   - yes | sdkmanager "platforms;android-$API_LEVEL" >/dev/null # Current Android compileSDK
 install:
   # Download Emulator Files
-  - yes | sdkmanager "platforms;android-$ANDROID_EMULATOR_API_LEVEL" >/dev/null # Android Emulator Platform
-  - yes | sdkmanager "emulator" >/dev/null
-  - yes | sdkmanager "system-images;android-$ANDROID_EMULATOR_API_LEVEL;$ANDROID_FLAVOUR;$ANDROID_ABI" >/dev/null # Android Emulator Image
+  - if [ $ESPRESSO -eq 1 ]; then yes | sdkmanager "platforms;android-$ANDROID_EMULATOR_API_LEVEL" >/dev/null; fi # Android Emulator Platform
+  - if [ $ESPRESSO -eq 1 ]; then yes | sdkmanager "emulator" >/dev/null; fi
+  - if [ $ESPRESSO -eq 1 ]; then yes | sdkmanager "system-images;android-$ANDROID_EMULATOR_API_LEVEL;$ANDROID_FLAVOUR;$ANDROID_ABI" >/dev/null; fi # Android Emulator Image
 
   # Setup Linux KVM
-  - sudo -E apt-get -yq --no-install-suggests --no-install-recommends install bridge-utils libpulse0 libvirt-bin qemu-kvm virtinst ubuntu-vm-builder
+  - then sudo -E apt-get -yq --no-install-suggests --no-install-recommends install bridge-utils libpulse0 libvirt-bin qemu-kvm virtinst ubuntu-vm-builder
   - sudo adduser $USER libvirt
   - sudo adduser $USER kvm
 
   # Launch Android Emulator
-  - avdmanager list
+  - if [ $ESPRESSO -eq 1 ]; then avdmanager list; fi
   - chmod +x ./travisscript/startemu.sh
   - chmod +x ./travisscript/android-wait-for-emulator.sh
   - ./travisscript/startemu.sh
@@ -75,20 +75,15 @@ install:
   - source ./travisscript/install-jdk-travis.sh
 before_script:
   # Original Steps continued
-  #- mkdir "$ANDROID_HOME/licenses" || true
-  #- echo -e "\n8933bad161af4178b1185d1a37fbf41ea5269c55" > "$ANDROID_HOME/licenses/android-sdk-license"
-  #- echo -e "\n84831b9409646a918e30573bab4c9c91346d8abd" > "$ANDROID_HOME/licenses/android-sdk-preview-license"
-  #- yes | sdkmanager "platforms;android-28" # Temporary fix for checksum mismatch (travis-ci/#8874)
   - openssl aes-256-cbc -K $encrypted_2969307dece5_key -iv $encrypted_2969307dece5_iv -in secrets.tar.enc -out secrets.tar -d
   - tar xvf secrets.tar
-  #- android list targets
   - chmod +x gradlew
-  #- chmod +x ./travisscript/startemu.sh
-  #- ./travisscript/startemu.sh
   #- ./gradlew clean # Uncomment to clean cache
   - travis_retry ./gradlew assembleDebug
   - travis_retry ./gradlew assembleDebugAndroidTest
-script: if [ $ESPRESSO -eq 1 ]; then travis_retry travis_wait ./gradlew connectedAndroidTest -x assembleDebug -x assembleDebugAndroidTest; else travis_retry travis_wait ./gradlew test -x assembleDebug -x assembleDebugAndroidTest; fi
+# Disable wait as it seems fast enough now
+#script: if [ $ESPRESSO -eq 1 ]; then travis_retry travis_wait ./gradlew connectedAndroidTest -x assembleDebug -x assembleDebugAndroidTest; else travis_retry travis_wait ./gradlew test -x assembleDebug -x assembleDebugAndroidTest; fi
+script: if [ $ESPRESSO -eq 1 ]; then travis_retry ./gradlew connectedAndroidTest -x assembleDebug -x assembleDebugAndroidTest; else travis_retry ./gradlew test -x assembleDebug -x assembleDebugAndroidTest; fi
 after_success:
   - mv ./app/build/outputs/apk/debug/app-debug.apk ./app/build/outputs/apk/debug/CheesecakeUtilities-debug.apk
   - ls ./app/build/outputs/apk/

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ install:
   - if [ $ESPRESSO -eq 1 ]; then yes | sdkmanager "system-images;android-$ANDROID_EMULATOR_API_LEVEL;$ANDROID_FLAVOUR;$ANDROID_ABI" >/dev/null; fi # Android Emulator Image
 
   # Setup Linux KVM
-  - then sudo -E apt-get -yq --no-install-suggests --no-install-recommends install bridge-utils libpulse0 libvirt-bin qemu-kvm virtinst ubuntu-vm-builder
+  - sudo -E apt-get -yq --no-install-suggests --no-install-recommends install bridge-utils libpulse0 libvirt-bin qemu-kvm virtinst ubuntu-vm-builder
   - sudo adduser $USER libvirt
   - sudo adduser $USER kvm
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ cache:
 env:
   global:
     - API_LEVEL=28
-    - ANDROID_EMULATOR_API_LEVEL=28 # Try on 28 first for emulator, if it works we can go 29
+    - ANDROID_EMULATOR_API_LEVEL=29
     - ANDROID_BUILD_TOOLS_VERSION=28.0.3
     - ANDROID_ABI=x86_64
     - ANDROID_FLAVOUR=google_apis # Use default for non-google
@@ -74,7 +74,6 @@ install:
   - JDK="${TARGET_JDK}"
   - source ./travisscript/install-jdk-travis.sh
 before_script:
-  # Original Steps continued
   - openssl aes-256-cbc -K $encrypted_2969307dece5_key -iv $encrypted_2969307dece5_iv -in secrets.tar.enc -out secrets.tar -d
   - tar xvf secrets.tar
   - chmod +x gradlew

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,8 +65,9 @@ install:
   - sudo adduser $USER kvm
 
   # Launch Android Emulator
-  - android list targets
+  - avdmanager list target -c
   - chmod +x ./travisscript/startemu.sh
+  - chmod +x ./travisscript/android-wait-for-emulator.sh
   - ./travisscript/startemu.sh
 
   # Switch back to target JDK

--- a/travisscript/.travis.yml.old
+++ b/travisscript/.travis.yml.old
@@ -1,6 +1,7 @@
-language: bash # Cannot use android for kvm
+language: android
+jdk: oraclejdk8
 sudo: true
-dist: bionic # Bionic is needed for KVM Nested Virtualization
+dist: trusty # Use Ubuntu 14.04 as its faster
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
   - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
@@ -14,20 +15,13 @@ cache:
 env:
   global:
     - API_LEVEL=28
-    - ANDROID_EMULATOR_API_LEVEL=28 # Try on 28 first for emulator, if it works we can go 29
+    - ANDROID_EMULATOR_API_LEVEL=25
     - ANDROID_BUILD_TOOLS_VERSION=28.0.3
-    - ANDROID_ABI=x86_64
-    - ANDROID_FLAVOUR=google_apis # Use default for non-google
+    - ANDROID_ABI=google_apis/arm64-v8a
     - ADB_INSTALL_TIMEOUT=20
     - ANDROID_TARGET=android-25
     - ANDROID_TAG=google_apis
     - DISCORD_URL=https://raw.githubusercontent.com/itachi1706/travis-ci-discord-webhook/master/send.sh
-    # KVM Self setup of Android SDK
-    - ANDROID_HOME=${HOME}/android-sdk # Default location for SDK
-    - ANDROID_TOOLS_URL="https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip" # From Android Dev Site
-    - JDK="1.8" # Android JDK
-    - TOOLS=${ANDROID_HOME}/tools # SDK Tools Location
-    - PATH=${ANDROID_HOME}:${ANDROID_HOME}/emulator:${TOOLS}:${TOOLS}/bin:${ANDROID_HOME}/platform-tools:${PATH}
   matrix:
     - ESPRESSO=1 # Espresso Instrumentation Tests
     - ESPRESSO=0 # Unit Tests
@@ -35,55 +29,29 @@ matrix:
     allow_failures:
         - env: ESPRESSO=1
     fast_finish: true
+android:
+  components:
+    - tools
+    - platform-tools
+    - tools
+    - build-tools-$ANDROID_BUILD_TOOLS_VERSION
+    - android-$API_LEVEL
+    - android-$ANDROID_EMULATOR_API_LEVEL
+    - extra-google-m2repository
+    - extra-android-m2repository
+    - addon-google_apis-google-$ANDROID_EMULATOR_API_LEVEL
+    - sys-img-arm64-v8a-google_apis-$ANDROID_EMULATOR_API_LEVEL
 before_install:
-  # Setup Android SDK JDK
-  - export TARGET_JDK="${JDK}"
-  - JDK="1.8"
-  - chmod +x ./travisscript/install-jdk-travis.sh
-  - source ./travisscript/install-jdk-travis.sh
-
-  # Setup Android SDK
-  - wget -q "${ANDROID_TOOLS_URL}" -O android-sdk-tools.zip
-  - unzip -q android-sdk-tools.zip -d ${ANDROID_HOME}
-  - rm android-sdk-tools.zip
-  - mkdir ~/.android
-  - echo 'count=0' > ~/.android/repositories.cfg
-  - yes | sdkmanager --licenses >/dev/null
-  - yes | sdkmanager "platform-tools"
-  - yes | sdkmanager "tools"
-  - yes | sdkmanager "build-tools;$ANDROID_BUILD_TOOLS_VERSION"
-  - yes | sdkmanager "platform;android-$API_LEVEL" # Current Android compileSDK
-install:
-  # Download Emulator Files
-  - yes | sdkmanager "platform;android-$ANDROID_EMULATOR_API_LEVEL" # Android Emulator Platform
-  - yes | sdkmanager "emulator"
-  - yes | sdkmanager "system-images;android-$ANDROID_EMULATOR_API_LEVEL;$ANDROID_FLAVOUR;$ANDROID_ABI" # Android Emulator Image
-
-  # Setup Linux KVM
-  - sudo -E apt-get -yq --no-install-suggests --no-install-recommends install bridge-utils libpulse0 libvirt-bin qemu-kvm virtinst ubuntu-vm-builder
-  - sudo adduser $USER libvirt
-  - sudo adduser $USER kvm
-
-  # Launch Android Emulator
-  - android list targets
-  - chmod +x ./travisscript/startemu.sh
-  - ./travisscript/startemu.sh
-
-  # Switch back to target JDK
-  - JDK="${TARGET_JDK}"
-  - source ~/.install-jdk-travis.sh
-before_script:
-  # Original Steps continued
-  #- mkdir "$ANDROID_HOME/licenses" || true
-  #- echo -e "\n8933bad161af4178b1185d1a37fbf41ea5269c55" > "$ANDROID_HOME/licenses/android-sdk-license"
-  #- echo -e "\n84831b9409646a918e30573bab4c9c91346d8abd" > "$ANDROID_HOME/licenses/android-sdk-preview-license"
-  #- yes | sdkmanager "platforms;android-28" # Temporary fix for checksum mismatch (travis-ci/#8874)
+  - mkdir "$ANDROID_HOME/licenses" || true
+  - echo -e "\n8933bad161af4178b1185d1a37fbf41ea5269c55" > "$ANDROID_HOME/licenses/android-sdk-license"
+  - echo -e "\n84831b9409646a918e30573bab4c9c91346d8abd" > "$ANDROID_HOME/licenses/android-sdk-preview-license"
+  - yes | sdkmanager "platforms;android-28" # Temporary fix for checksum mismatch (travis-ci/#8874)
   - openssl aes-256-cbc -K $encrypted_2969307dece5_key -iv $encrypted_2969307dece5_iv -in secrets.tar.enc -out secrets.tar -d
   - tar xvf secrets.tar
-  #- android list targets
+  - android list targets
   - chmod +x gradlew
-  #- chmod +x ./travisscript/startemu.sh
-  #- ./travisscript/startemu.sh
+  - chmod +x ./travisscript/startemu.sh
+  - ./travisscript/startemu.sh
   #- ./gradlew clean # Uncomment to clean cache
   - travis_retry ./gradlew assembleDebug
   - travis_retry ./gradlew assembleDebugAndroidTest

--- a/travisscript/android-wait-for-emulator.sh
+++ b/travisscript/android-wait-for-emulator.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Originally written by Ralf Kistner <ralf@embarkmobile.com>, but placed in the public domain
+
+set +e
+
+bootanim=""
+failcounter=0
+timeout_in_sec=360
+
+until [[ "$bootanim" =~ "stopped" ]]; do
+  bootanim=`adb -e shell getprop init.svc.bootanim 2>&1 &`
+  if [[ "$bootanim" =~ "device not found" || "$bootanim" =~ "device offline"
+    || "$bootanim" =~ "running" ]]; then
+    let "failcounter += 1"
+    echo "Waiting for emulator to start"
+    if [[ $failcounter -gt timeout_in_sec ]]; then
+      echo "Timeout ($timeout_in_sec seconds) reached; failed to start emulator"
+      exit 1
+    fi
+  fi
+  sleep 1
+done
+
+echo "Emulator is ready"

--- a/travisscript/install-jdk-travis.sh
+++ b/travisscript/install-jdk-travis.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+install_jdk () {
+    if $jabba use $ACTUAL_JDK; then
+        echo $ACTUAL_JDK was available and Jabba is using it
+    else
+        echo installing $ACTUAL_JDK
+        $jabba install "$ACTUAL_JDK" || exit $?
+        echo setting $ACTUAL_JDK as Jabba default
+        $jabba use $ACTUAL_JDK || exit $?
+    fi
+}
+
+unix_pre () {
+    curl -sL https://github.com/shyiko/jabba/raw/master/install.sh | bash && . ~/.jabba/jabba.sh
+    unset _JAVA_OPTIONS
+    export jabba=jabba
+}
+
+install_jabba_on_linux () {
+    unix_pre
+}
+
+install_jabba_on_osx () {
+    unix_pre
+    export JAVA_HOME="$HOME/.jabba/jdk/$ACTUAL_JDK/Contents/Home"
+}
+
+install_jabba_on_windows () {
+    PowerShell -ExecutionPolicy Bypass -Command '[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; Invoke-Expression (Invoke-WebRequest https://github.com/shyiko/jabba/raw/master/install.ps1 -UseBasicParsing).Content'
+    export jabba="$HOME/.jabba/bin/jabba.exe"
+}
+
+complete_installation_on_linux () {
+    echo 
+}
+
+complete_installation_on_osx () {
+    export JAVA_HOME="$HOME/.jabba/jdk/$ACTUAL_JDK/Contents/Home"
+}
+
+complete_installation_on_windows () {
+    # Windows is unable to clean child processes, so no Gradle daemon allowed
+    export GRADLE_OPTS="-Dorg.gradle.daemon=false $GRADLE_OPTS"
+    echo 'export GRADLE_OPTS="-Dorg.gradle.daemon=false $GRADLE_OPTS"' >> ~/.jdk_config
+}
+
+set -e
+if [ -z $JDK ]
+then
+    echo "No JDK variable provided."
+    exit 1
+fi
+echo "running ${TRAVIS_OS_NAME}-specific configuration"
+echo "installing Jabba"
+install_jabba_on_$TRAVIS_OS_NAME
+echo "Computing best match for required JDK version: $JDK"
+ACTUAL_JDK="$(echo $($jabba ls-remote | grep -m1 $JDK))"
+echo "Selected JDK: $ACTUAL_JDK"
+if [ -z $ACTUAL_JDK ]
+then
+    echo "No JDK version is compatible with $JDK. Available JDKs are:"
+    "$jabba" ls-remote
+    exit 2
+else
+    echo "Best match is $ACTUAL_JDK"
+    export JAVA_HOME="$HOME/.jabba/jdk/$ACTUAL_JDK"
+    complete_installation_on_$TRAVIS_OS_NAME
+    export PATH="$JAVA_HOME/bin:$PATH"
+    # Apparently exported variables are ignored in subseguent phases on Windows. Write in config file
+    echo "export JAVA_HOME=\"${JAVA_HOME}\"" >> ~/.jdk_config
+    echo "export PATH=\"${PATH}\"" >> ~/.jdk_config
+    install_jdk
+    which java
+    java -Xmx32m -version
+    set +e
+fi

--- a/travisscript/startemu.sh
+++ b/travisscript/startemu.sh
@@ -7,7 +7,7 @@ then
     EMU_COMMAND="emulator"
     sudo -E sudo -u $USER -E bash -c "${ANDROID_HOME}/emulator/${EMU_COMMAND} -avd test ${AUDIO} ${EMU_PARAMS} &"
 
-    android-wait-for-emulator
+    ./travisscript/android-wait-for-emulator
     adb shell input keyevent 82 &
 
     # Old Code

--- a/travisscript/startemu.sh
+++ b/travisscript/startemu.sh
@@ -2,12 +2,12 @@
 
 if [ $ESPRESSO -eq 1 ]
 then
-    echo no | avdmanager create avd --force -n test -k "system-images;android-$API;$EMU_FLAVOR;$ABI" -c 10M
+    echo no | avdmanager create avd --force -n test -k "system-images;android-$ANDROID_EMULATOR_API_LEVEL;$ANDROID_FLAVOUR;$ANDROID_ABI" -c 10M
     EMU_PARAMS="-verbose -no-snapshot -no-window -camera-back none -camera-front none -selinux permissive -qemu -m 2048"
     EMU_COMMAND="emulator"
     sudo -E sudo -u $USER -E bash -c "${ANDROID_HOME}/emulator/${EMU_COMMAND} -avd test ${AUDIO} ${EMU_PARAMS} &"
 
-    ./travisscript/android-wait-for-emulator
+    ./travisscript/android-wait-for-emulator.sh
     adb shell input keyevent 82 &
 
     # Old Code

--- a/travisscript/startemu.sh
+++ b/travisscript/startemu.sh
@@ -2,8 +2,17 @@
 
 if [ $ESPRESSO -eq 1 ]
 then
-    echo no | android create avd --force -n test -t $ANDROID_TARGET --abi $ANDROID_ABI --tag $ANDROID_TAG
-    emulator -avd test -no-window &
+    echo no | avdmanager create avd --force -n test -k "system-images;android-$API;$EMU_FLAVOR;$ABI" -c 10M
+    EMU_PARAMS="-verbose -no-snapshot -no-window -camera-back none -camera-front none -selinux permissive -qemu -m 2048"
+    EMU_COMMAND="emulator"
+    sudo -E sudo -u $USER -E bash -c "${ANDROID_HOME}/emulator/${EMU_COMMAND} -avd test ${AUDIO} ${EMU_PARAMS} &"
+
     android-wait-for-emulator
     adb shell input keyevent 82 &
+
+    # Old Code
+    #echo no | android create avd --force -n test -t $ANDROID_TARGET --abi $ANDROID_ABI --tag $ANDROID_TAG
+    #emulator -avd test -no-window &
+    #android-wait-for-emulator
+    #adb shell input keyevent 82 &
 fi


### PR DESCRIPTION
This PR finally allows us to make use of Android x86_64 emulators and bump our emulator to API 29 (Android 10)

This is due to the fact that we have converted the Travis CI build to allow us to make use of KVM Virtualization for hardware acceleration for emulators.

We can also clearly see the difference in terms of build speeds right now as well

**Old Build Times**   

| Build Mode | Timings |
| --- | --- |
| Non-Espresso | 12 minutes 38 seconds |
| Espresso | 26 minutes 13 seconds |
| Total | 38 minutes 51 seconds |

**New Build Times**

Build Mode | Timings | Faster by (%) (3sf)
------------ | ------------- | ----
Non-Espresso | 7 minutes 41 seconds | 48.7%
Espresso | 17 minutes 10 seconds | 41.7%
Total | 24 minutes 51 seconds | 44.0%

Resolves CUTILAND-363